### PR TITLE
feat: add Watir so more ensembles can be scraped

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 
 gem "rake", "~> 12.0"
 gem "colorize"
+gem "watir"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    childprocess (3.0.0)
     coderay (1.1.3)
     colorize (0.8.1)
     method_source (1.0.0)
@@ -22,6 +23,14 @@ GEM
       method_source (~> 1.0)
     racc (1.5.2)
     rake (12.3.3)
+    regexp_parser (2.1.1)
+    rubyzip (2.3.2)
+    selenium-webdriver (3.142.7)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
+    watir (6.19.1)
+      regexp_parser (>= 1.2, < 3)
+      selenium-webdriver (>= 3.142.7)
 
 PLATFORMS
   ruby
@@ -32,6 +41,7 @@ DEPENDENCIES
   percussion_ensembles!
   pry
   rake (~> 12.0)
+  watir
 
 BUNDLED WITH
-   2.1.4
+   2.2.21

--- a/lib/environment.rb
+++ b/lib/environment.rb
@@ -8,6 +8,7 @@ require 'nokogiri'
 require 'open-uri'
 require 'pry'
 require 'colorize'
+require 'watir'
 
 module PercussionEnsembles
   class Error < StandardError; end

--- a/lib/percussion_ensembles/scraper.rb
+++ b/lib/percussion_ensembles/scraper.rb
@@ -13,9 +13,9 @@ class PercussionEnsembles::Scraper
 
             ensemble_title = card.css("div.catalog-product-image img").first["title"]
 
-            full_name = card.css("div.catalog-product-title a:nth-of-type(2)").first["title"].split
-            composer_name = "#{full_name.last}, #{full_name[0]}"
-            
+            full_name = card.css("div.catalog-product-title a:nth-of-type(2)").any? ? card.css("div.catalog-product-title a:nth-of-type(2)").first["title"].split : ["Multiple", "Composers"]
+            composer_name = full_name[1] === "Composers" ? "#{full_name[0]} #{full_name[1]}" : "#{full_name.last}, #{full_name[0]}"
+
             composer = PercussionEnsembles::Composer.find_or_create_by(composer_name)
             
             more_info = card.css("div.catalog-fields")

--- a/lib/percussion_ensembles/scraper.rb
+++ b/lib/percussion_ensembles/scraper.rb
@@ -1,6 +1,12 @@
 class PercussionEnsembles::Scraper
     def scrape(site)
-        doc = Nokogiri::HTML(URI.open(site))
+        browser = Watir::Browser.new :safari
+        browser.goto site
+        25.times do
+            browser.send_keys :end
+            sleep 0.5
+        end
+        doc = Nokogiri::HTML(browser.html)
 
         doc.css("div.catalog-list2").map do |card|
             current_ensemble = {}
@@ -25,6 +31,7 @@ class PercussionEnsembles::Scraper
                     current_ensemble.merge!(full_details)
                 end
             end
+            browser.close
             current_ensemble
         end
     end


### PR DESCRIPTION
This PR adds Watir into the mix, opening a Safari browser window, scrolling to the bottom of the page, until no more ensembles load in, then parsing with Nokogiri. This can for all intents and purposes scrape the entire Tapspace library.